### PR TITLE
Exclude config.json from service worker precache

### DIFF
--- a/asset-manifest.js
+++ b/asset-manifest.js
@@ -1,5 +1,5 @@
 self.__ASSET_MANIFEST = {
-  "version": "90deb8b4",
+  "version": "5cdb7ee6",
   "files": [
     "./",
     "./index.html",
@@ -12,7 +12,6 @@ self.__ASSET_MANIFEST = {
     "./collaboration.js",
     "./third_party/strip-metadata.js",
     "./icons/icon-192.png",
-    "./icons/icon-512.png",
-    "./config.json"
+    "./icons/icon-512.png"
   ]
 };

--- a/build-manifest.js
+++ b/build-manifest.js
@@ -14,8 +14,7 @@ const crypto = require('crypto');
     'collaboration.js',
     'third_party/strip-metadata.js',
     'icons/icon-192.png',
-    'icons/icon-512.png',
-    'config.json'
+    'icons/icon-512.png'
   ];
 
 const root = __dirname;
@@ -23,7 +22,7 @@ const root = __dirname;
 function createManifest() {
   const hash = crypto.createHash('sha256');
 
-  // Write config.json from environment variables
+  // Write config.json from environment variables (not part of the asset manifest)
   const config = {
     clientId: process.env.GDRIVE_CLIENT_ID || '',
     apiKey: process.env.GDRIVE_API_KEY || ''

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,8 @@
 importScripts('./asset-manifest.js');
 
 const CACHE_NAME = `terminal-list-${self.__ASSET_MANIFEST.version}`;
-const ASSETS = self.__ASSET_MANIFEST.files;
+// Exclude config.json from precache assets
+const ASSETS = self.__ASSET_MANIFEST.files.filter(f => f !== './config.json');
 const NO_STORE_PATHS = ['/config.json'];
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- omit `config.json` from the asset manifest generation
- ensure service worker doesn't precache `config.json` while still enforcing `no-store` on runtime fetches
- regenerate asset manifest without `config.json`

## Testing
- `node build-manifest.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1d0179208331be869778a58878ee